### PR TITLE
update readme, default data/files and install.sls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,11 @@ Available states
 ``gerrit``
 ----------
 
-Install gerrit and start up the gerrit service. (Currently tested under Ubuntu 14.04 LTS).
+Install gerrit and start up the gerrit service.
+
+Currently tested under:
+- Debian 8.3 Jessie
+- Ubuntu 14.04 LTS
 
 For a list of all available options, look at: `gerrit/defaults.yaml` - also have a look at the pillar.example and map.jinja.
 

--- a/gerrit/defaults.yaml
+++ b/gerrit/defaults.yaml
@@ -3,14 +3,12 @@
 
 gerrit:
   base_directory: /opt/gerrit
-  site_directory: gerrit-site
-  user: gerrit2
-  group: gerrit2
-  
-  install:
+  site_directory: review
+  package:
+    version: 2.12.1
     base_url: https://gerrit-releases.storage.googleapis.com
-    version: 2.11.3
-
-  service:
-    name: gerrit
-
+  user: gerrit
+  group: gerrit
+  config:
+    canonical_web_url: http://localhost:8080
+  service: gerrit-server

--- a/gerrit/files/gerrit.config
+++ b/gerrit/files/gerrit.config
@@ -1,0 +1,26 @@
+{% from "gerrit/map.jinja" import settings with context -%}
+{% set war_file = "gerrit-" + settings.package.version + ".war" -%}
+
+[gerrit]
+        basePath = git
+        canonicalWebUrl = {{ settings.canonical_web_url }}
+[database]
+        type = h2
+        database = /opt/{{ settings.base_directory }}/{{ settings.site_directory }}/db/ReviewDB
+[index]
+        type = LUCENE
+        onlineUpgrade = true
+[auth]
+        type = DEVELOPMENT_BECOME_ANY_ACCOUNT
+[sendemail]
+        smtpServer = localhost
+[container]
+        user = {{ settings.user }}
+        javaHome = /usr/lib/jvm/java-7-openjdk-amd64/jre
+        war = {{ settings.base_directory }}/{{ war_file }}
+[sshd]
+        listenAddress = *:29418
+[httpd]
+        listenUrl = http://*:8080/
+[cache]
+        directory = cache

--- a/gerrit/files/gerritcodereview.jinja
+++ b/gerrit/files/gerritcodereview.jinja
@@ -1,3 +1,0 @@
-{% from "gerrit/map.jinja" import gerrit_settings with context -%}
-
-GERRIT_SITE={{ gerrit_settings.base_directory }}/{{ gerrit_settings.site_directory }}

--- a/gerrit/map.jinja
+++ b/gerrit/map.jinja
@@ -5,7 +5,7 @@
 {% import_yaml "gerrit/defaults.yaml" as default_settings %}
 
 {# Update settings defaults from pillar data #}
-{% set gerrit_settings = salt['pillar.get'](
+{% set settings = salt['pillar.get'](
     'gerrit',
     default=default_settings.gerrit,
     merge=True)


### PR DESCRIPTION
- Minor change is that the README.rst has been updated to reflect that this has been tested on Debian 8.3 Jessie
- Updated and added attribute data in defaults.yaml
- Removed gerritcodereview from "files" and create it dynamically using the content parameter since it's one line
- Now managing gerrit.config secure.config in "files" with sane defaults, but secure.config is blank
- Create the "etc" and "plugins" directories along with parent structure using makedirs
- Use wget as opposed to curl and save the war file top the base directory: #1 
- Reindex as soon as you init the war file
- Updated names of various attributes/values and variables to something either more semantic or brief, because of the context in which they're used
