### PR TITLE
Make logs symlink and update JRE version

### DIFF
--- a/gerrit/install.sls
+++ b/gerrit/install.sls
@@ -74,6 +74,13 @@ gerrit_init:
     - cwd: {{ settings.base_directory }}
     - unless: test -d {{ settings.base_directory }}/{{ settings.site_directory }}/bin
 
+link_logs_to_var_log_gerrit:
+  file.symlink:
+    - name: /var/log/gerrit
+    - target: {{ settings.base_directory }}/{{ settings.site_directory }}/logs
+    - user: root
+    - group: root
+
 gerrit_init_script:
   file.symlink:
     - name: /etc/init.d/{{ settings.service }}

--- a/gerrit/map.jinja
+++ b/gerrit/map.jinja
@@ -13,7 +13,7 @@ that differ from whats in defaults.yaml
       'jre': 'default-jre',
     },
     'RedHat': {
-      'jre': 'java-1.7.0-openjdk',
+      'jre': 'java-1.8.0-openjdk',
     },
     'Arch': {},
   }, grain='os_family', merge=salt['pillar.get']('gerrit:lookup'))


### PR DESCRIPTION
This is more convinient to have logs in /var/log/gerrit instead of
looking for site folder.
Use JRE 1.8 because of 1.7 for CentOS7.
