### PR TITLE
Add the possibility install core plugins

### DIFF
--- a/gerrit/defaults.yaml
+++ b/gerrit/defaults.yaml
@@ -17,4 +17,5 @@ gerrit:
       hostname: localhost
       username: gerrit
       password: gerrit
+  core_plugins:
   service: gerrit-server

--- a/gerrit/install.sls
+++ b/gerrit/install.sls
@@ -91,7 +91,13 @@ gerrit_war:
 gerrit_init:
   cmd.run:
     - name: |
+{% if settings.core_plugins is not none %}
+    {% for plugin in settings.core_plugins %}
+        java -jar {{ settings.base_directory }}/{{ gerrit_war_file }} init --batch --install-plugin {{ plugin }} -d {{ settings.base_directory }}/{{ settings.site_directory }}
+    {% endfor %}
+{% else %}
         java -jar {{ settings.base_directory }}/{{ gerrit_war_file }} init --batch -d {{ settings.base_directory }}/{{ settings.site_directory }}
+{% endif %}
         java -jar {{ settings.base_directory }}/{{ gerrit_war_file }} reindex -d {{ settings.base_directory }}/{{ settings.site_directory }}
     - user: {{ settings.user }}
     - group: {{ settings.group }}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 gerrit:
+  config:
     database:
       # Supports h2 and other database types, but h2 and mysql are well tested ONLY
       type: h2
@@ -15,3 +16,8 @@ gerrit:
       github-plugin:
         source: https://gerrit-ci.gerritforge.com/view/Plugins-stable-2.12/job/plugin-github-mvn-stable-2.12/3/artifact/github-plugin/target/github-plugin-2.12-SNAPSHOT.jar
         source_hash: md5=42ebd7a68c6e0a35e7885c69b28c503b
+  # Install core plugins https://gerrit-review.googlesource.com/Documentation/config-plugins.html#core-plugins
+  # For example to install such core plugins as replication and download-commands
+  core_plugins:
+    - replication
+    - download-commands


### PR DESCRIPTION
Gerrit war file has packaged core plugins [1] which can be easily installed.
For example to install plugins replication and download-commands below
pillars should be added:

`core_plugins:`
`- replication`
`- download-commands`

[1] https://gerrit-review.googlesource.com/Documentation/config-plugins.html#core-plugins
