### PR TITLE
Allow to add custom sections in gerrit.config

### DIFF
--- a/gerrit/defaults.yaml
+++ b/gerrit/defaults.yaml
@@ -21,5 +21,6 @@ gerrit:
       hostname: localhost
       username: gerrit
       password: gerrit
+  config_custom_sections:
   core_plugins:
   service: gerrit-server

--- a/gerrit/files/gerrit.config
+++ b/gerrit/files/gerrit.config
@@ -34,3 +34,11 @@
         listenUrl = http://*:8080/
 [cache]
         directory = cache
+{%- if settings.config_custom_sections is not none -%}
+    {% for custom_section, custom_section_options in settings.config_custom_sections.items() %}
+[{{ custom_section  }}]
+        {%- for custom_section_option, custom_section_value in custom_section_options.items() %}
+        {{ custom_section_option }} = {{ custom_section_value }}
+        {%- endfor %}
+    {%- endfor %}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,14 @@ gerrit:
       hostname: localhost
       username: gerrit
       password: gerrit
+  # Configure custom config sections in gerrit.config
+  # Below example shows how to configure github-plugin section
+  config_custom_sections:
+    github:
+        url: https://github.com
+        apiUrl: https://api.github.com
+        clientId: 12343e611234c6ab4321
+        clientSecret: 123475f1d4da1234f1658b123432d5dfa27a4321
   # Install core plugins https://gerrit-review.googlesource.com/Documentation/config-plugins.html#core-plugins
   # For example to install such core plugins as replication and download-commands
   core_plugins:


### PR DESCRIPTION
There are some plugins such as github and OAuth authentication
provider which put their configs in own sections in gerrit.config.
