### PR TITLE
Add the possibility to configure the sshd and httpd sections

### DIFF
--- a/gerrit/defaults.yaml
+++ b/gerrit/defaults.yaml
@@ -21,6 +21,10 @@ gerrit:
       hostname: localhost
       username: gerrit
       password: gerrit
+    sshd:
+      listenAddress: '*:29418'
+    httpd:
+      listenUrl: http://*:8080/
   config_custom_sections:
   core_plugins:
   service: gerrit-server

--- a/gerrit/files/gerrit.config
+++ b/gerrit/files/gerrit.config
@@ -29,9 +29,13 @@
         javaHome = {{ settings.java_home|default(salt['cmd.run']('readlink -f /usr/bin/java | sed "s:bin/java::"')) }}
         war = {{ settings.base_directory }}/{{ war_file }}
 [sshd]
-        listenAddress = *:29418
+{%- for sshd_option, option_value in settings.config.sshd.items() %}
+        {{ sshd_option }} = {{ option_value }}
+{%- endfor %}
 [httpd]
-        listenUrl = http://*:8080/
+{%- for httpd_option, option_value in settings.config.httpd.items() %}
+        {{ httpd_option }} = {{ option_value }}
+{%- endfor %}
 [cache]
         directory = cache
 {%- if settings.config_custom_sections is not none -%}

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,18 @@ gerrit:
       hostname: localhost
       username: gerrit
       password: gerrit
+    # Configure the sshd section https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#sshd
+    sshd:
+      # to listen on ip address 10.1.12.125 put below pillar
+      listenAddress: 10.1.12.125:29418
+    # Configure the httpd section https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#httpd
+    httpd:
+      # to listen on ip address 192.168.1.12 put below pillar
+      listenUrl: http://192.168.1.12/
+      # Plain-text HTTP relayed from a reverse proxy
+      listenUrl: proxy-http://192.168.1.12:8080
+      # to specify class that implements the javax.servlet.Filter interface
+      filterClass = org.anyorg.MySecureFilter
   # Configure custom config sections in gerrit.config
   # Below example shows how to configure github-plugin section
   config_custom_sections:


### PR DESCRIPTION
- Define the defaults values for sshd and httpd sections in defaults.yaml
- Allow to configure all possible options for sshd and httpd sections
