### PR TITLE
Add the possibility to configure secure.config [1]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,23 @@ Currently tested under:
 
 For a list of all available options, look at: `gerrit/defaults.yaml` - also have a look at the pillar.example and map.jinja.
 
+Obligatory pillar
+=================
+
+Pillar **registerEmailPrivateKey** is mandatory because if you do not generate it gerrit init will generate it
+for you but then saltstack will remove it from config file during next run.
+
+The one of the ways to do it use command **openssl rand -base64 36**
+
+Structure example:
+
+.. code:: yaml
+
+ gerrit:
+   secure:
+     auth:
+       registerEmailPrivateKey: 'generate me by "openssl rand -base64 36"'
+
 Testing
 =======
 

--- a/gerrit/defaults.yaml
+++ b/gerrit/defaults.yaml
@@ -33,6 +33,8 @@ gerrit:
     index:
       type: LUCENE
       onlineUpgrade: true
+  secure:
+    auth:
   config_custom_sections:
   core_plugins:
   service: gerrit-server

--- a/gerrit/files/secure.config
+++ b/gerrit/files/secure.config
@@ -1,0 +1,8 @@
+{%- if secure is not none -%}
+    {%- for secure_section, secure_section_options in secure.items() -%}
+[{{ secure_section  }}]
+        {%- for secure_section_option, secure_section_value in secure_section_options.items() %}
+        {{ secure_section_option }} = {{ secure_section_value }}
+        {%- endfor %}
+    {%- endfor %}
+{%- endif %}

--- a/gerrit/install.sls
+++ b/gerrit/install.sls
@@ -90,6 +90,8 @@ secure_config:
     - user: {{ settings.user }}
     - group: {{ settings.group }}
     - makedirs: true
+    - defaults:
+        secure: {{ settings.secure|json }}
 
 /etc/default/gerritcodereview:
   file.managed:

--- a/pillar.example
+++ b/pillar.example
@@ -49,6 +49,15 @@ gerrit:
     receive:
       # Configure number of threads to perform change creation or patch set updates concurrently
       changeUpdateThreads: 5
+  # Format secure.conf file content https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#secure.config
+  secure:
+    auth:
+      registerEmailPrivateKey: AMahuFyehfwr5mTldZNfBg9LsnRIDvfc8yn/DQ08jAA0Y7VV
+    database:
+      username: webuser
+      password: s3kr3t
+    ldap
+      password: l3tm3srch
   # Configure custom config sections in gerrit.config
   # Below example shows how to configure github-plugin section
   config_custom_sections:


### PR DESCRIPTION
- Add to defaults.yaml secure structure
- Make secure.config template
- Add to doc that registerEmailPrivateKey is mandatory pillar

[1] https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#secure.config
